### PR TITLE
Add "Insert link to current note in other vault" command

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,6 @@
 import { Editor, MarkdownView } from 'obsidian';
 import VaultTransferPlugin from 'main';
-import { transferNote } from 'transfer';
+import { insertLinkToOtherVault, transferNote } from 'transfer';
 
 export function addCommands(plugin: VaultTransferPlugin) {
     // Transfer note to other vault
@@ -9,6 +9,15 @@ export function addCommands(plugin: VaultTransferPlugin) {
         name: 'Transfer current note to other vault',
         editorCallback: (editor: Editor, view: MarkdownView) => {
             transferNote(editor, view, plugin.app, plugin.settings);
+        }
+    });
+
+    // Insert link to note in other vault, without transferring
+    plugin.addCommand({
+        id: 'insert-link-to-note-in-vault',
+        name: 'Insert link to current note in other vault',
+        editorCallback: (editor: Editor, view: MarkdownView) => {
+            insertLinkToOtherVault(editor, view, plugin.settings)
         }
     });
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,7 +3,10 @@ import VaultTransferPlugin from 'main';
 import { insertLinkToOtherVault, transferNote } from 'transfer';
 
 export function addCommands(plugin: VaultTransferPlugin) {
-    // Transfer note to other vault
+    /**
+     * Transfers the contents of the current note to a file in the other vault with the same name.
+     * Then, replaces the contents of the current note with a link to the new file.
+     */
     plugin.addCommand({
         id: 'transfer-note-to-vault',
         name: 'Transfer current note to other vault',
@@ -12,12 +15,14 @@ export function addCommands(plugin: VaultTransferPlugin) {
         }
     });
 
-    // Insert link to note in other vault, without transferring
+    /**
+     * Inserts a link to the current note in the other vault, without transferring.
+     */
     plugin.addCommand({
         id: 'insert-link-to-note-in-vault',
         name: 'Insert link to current note in other vault',
         editorCallback: (editor: Editor, view: MarkdownView) => {
-            insertLinkToOtherVault(editor, view, plugin.settings)
+            insertLinkToOtherVault(editor, view, plugin.settings);
         }
     });
 }

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -9,8 +9,8 @@ import { showNotice } from 'utils';
 export function transferNote(editor: Editor, view: MarkdownView, app: App, settings: VaultTransferSettings) {
     try {
         // Check settings
-        const didSettingsError = showErrorIfSettingsInvalid(settings);
-        if (didSettingsError) {
+        const settingsErrorShown = showErrorIfSettingsInvalid(settings);
+        if (settingsErrorShown) {
             return;
         }
 
@@ -55,8 +55,9 @@ export function transferNote(editor: Editor, view: MarkdownView, app: App, setti
  * Inserts a link at the cursor to the current file in another vault.
  */
 export function insertLinkToOtherVault(editor: Editor, view: MarkdownView, settings: VaultTransferSettings) {
-    const didSettingsError = showErrorIfSettingsInvalid(settings);
-    if (didSettingsError) {
+    // Check settings
+    const settingsErrorShown = showErrorIfSettingsInvalid(settings);
+    if (settingsErrorShown) {
         return;
     }
 
@@ -64,7 +65,7 @@ export function insertLinkToOtherVault(editor: Editor, view: MarkdownView, setti
     const fileDisplayName = view.file.basename;
 
     // Get output vault
-    const outputVault = cleanPath(settings.outputVault);
+    const outputVault = settings.outputVault;
 
     // Insert link to file
     const link = createVaultFileLink(fileDisplayName, outputVault);
@@ -76,7 +77,7 @@ export function insertLinkToOtherVault(editor: Editor, view: MarkdownView, setti
  */
 function createVaultFileLink(fileDisplayName: string, outputVault: string): string {
     // Get content for link
-    const vaultPathArray = outputVault.split("/");
+    const vaultPathArray = cleanPath(outputVault).split("/");
     const vaultName = vaultPathArray[vaultPathArray.length - 1];
     const urlOtherVault = encodeURI(vaultName);
     const urlFile = encodeURI(fileDisplayName);
@@ -105,6 +106,9 @@ function showErrorIfSettingsInvalid(settings: VaultTransferSettings): boolean {
     return false;
 }
 
+/**
+ * Improves consistency of slashes in a path.
+ */
 function cleanPath(path: string): string {
     return path.trim()
         // Replace '\' with '/'

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -4,7 +4,7 @@ import { VaultTransferSettings } from 'settings';
 import { showNotice } from 'utils';
 
 /**
- * Copies the content of the current note to another vault, then inserts a link to the new file.
+ * Copies the content of the current note to another vault, then replaces existing note contents with a link to the new file.
  */
 export function transferNote(editor: Editor, view: MarkdownView, app: App, settings: VaultTransferSettings) {
     try {
@@ -86,7 +86,7 @@ function createVaultFileLink(fileDisplayName: string, outputVault: string): stri
 }
 
 /**
- * Ensures necessary info has been set in plugin settings.
+ * Ensures necessary info has been set in plugin settings, otherwise displays an error notice.
  * @returns True if an error was shown, otherwise false.
  */
 function showErrorIfSettingsInvalid(settings: VaultTransferSettings): boolean {


### PR DESCRIPTION
Sometimes I know a file exists in my other vault, so if I want a note with a link to it I have to do it manually.

This PR adds a command that simply inserts a link which takes you to the current file, but in the other vault. It also reorganizes some code to slightly reduce repetition.