### PR TITLE
feat: Transfer image alongside the file and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Obsidian Vault Transfer
+
 Transfers the contents of the selected note to another vault, then links to it from the original note.
 
 ## How to use
-1. Set the output vault and (optionally) output folder in the settings tab.
+
+1. Set the output vault and (optionally) output folder in the settings tab. You can also configure:
+    - To create a link to the transferred note in the original note. If set to `false`, you can allow the plugin to delete the original note.
+    - If the file must overwrite an existing file in the target vault.
 2. Confirm that the target vault and folder exist.
 3. Open the note you want to transfer.
 4. Run `Vault Transfer: Transfer current note to other vault`.
@@ -10,6 +14,7 @@ Transfers the contents of the selected note to another vault, then links to it f
 ![vault-transfer](https://user-images.githubusercontent.com/92801558/212498180-34ed6ddf-9800-4904-b5a8-209be067e992.gif)
 
 ## Other commands
+
 **Insert link to current note in other vault**
 
 Inserts a link to the current note in the other vault, without transferring the contents. Used when you know a file with the same name already exists in the other vault.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Transfers the contents of the selected note to another vault, then links to it f
 
 ![vault-transfer](https://user-images.githubusercontent.com/92801558/212498180-34ed6ddf-9800-4904-b5a8-209be067e992.gif)
 
+It is also possible to transfer multiple notes at once. In this case, the plugin will create a folder with the same name as the original folder, and transfer the notes inside it.
+
+You can also use the file-menu to transfer the folder or note, and you can also send to a specific folder in the target vault, or create a new folder in the target vault, and then transfer the note to it.
+
 ## Other commands
 
 **Insert link to current note in other vault**

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@typescript-eslint/parser": "5.29.0",
 				"builtin-modules": "3.3.0",
 				"esbuild": "0.14.47",
-				"obsidian": "latest",
+				"obsidian": "^1.2.8",
 				"tslib": "2.4.0",
 				"typescript": "4.7.4"
 			}
@@ -1371,9 +1371,9 @@
 			"peer": true
 		},
 		"node_modules/obsidian": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.1.1.tgz",
-			"integrity": "sha512-GcxhsHNkPEkwHEjeyitfYNBcQuYGeAHFs1pEpZIv0CnzSfui8p8bPLm2YKLgcg20B764770B1sYGtxCvk9ptxg==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.2.8.tgz",
+			"integrity": "sha512-HrC+feA8o0tXspj4lEAqxb1btwLwHD2oHXSwbbN+CdRHURqbCkuIDLld+nkuyJ1w1c9uvVDRVk8BoeOnWheOrQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/codemirror": "0.0.108",
@@ -2785,9 +2785,9 @@
 			"peer": true
 		},
 		"obsidian": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.1.1.tgz",
-			"integrity": "sha512-GcxhsHNkPEkwHEjeyitfYNBcQuYGeAHFs1pEpZIv0CnzSfui8p8bPLm2YKLgcg20B764770B1sYGtxCvk9ptxg==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.2.8.tgz",
+			"integrity": "sha512-HrC+feA8o0tXspj4lEAqxb1btwLwHD2oHXSwbbN+CdRHURqbCkuIDLld+nkuyJ1w1c9uvVDRVk8BoeOnWheOrQ==",
 			"dev": true,
 			"requires": {
 				"@types/codemirror": "0.0.108",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "3.3.0",
 		"esbuild": "0.14.47",
-		"obsidian": "latest",
+		"obsidian": "^1.2.8",
 		"tslib": "2.4.0",
 		"typescript": "4.7.4"
 	}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -27,6 +27,11 @@ export function addCommands(plugin: VaultTransferPlugin) {
     });
 }
 
+/**
+ * Add a command under the file menu to transfer the current file or folder to another vault.
+ * If a folder is selected, all files in the folder will be transferred.
+ * @param plugin {VaultTransferPlugin} The plugin instance
+ */
 export function addMenuCommands(plugin: VaultTransferPlugin) {
     plugin.registerEvent(
       plugin.app.workspace.on("file-menu", (menu, file) => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -51,7 +51,7 @@ export function addMenuCommands(plugin: VaultTransferPlugin) {
             const submenu = item.setSubmenu() as Menu;
             submenu.addItem((subitem) => {
             subitem
-              .setTitle("Transfer using settings")
+              .setTitle("Transfer")
               .setIcon("arrow-right-circle")
               .onClick(async () => {
               if (file instanceof TFolder) {
@@ -62,7 +62,7 @@ export function addMenuCommands(plugin: VaultTransferPlugin) {
               });
             submenu.addItem((subitem) => {
               subitem
-                .setTitle("Transfert in selected folder...")
+                .setTitle("Transfert to...")
                 .setIcon("arrow-right-circle")
                 .onClick(async () => {
                   //get all folder in the output vault
@@ -75,11 +75,12 @@ export function addMenuCommands(plugin: VaultTransferPlugin) {
                         relPath: folder
                       }
                     });
-                    
+                    //add an option to transfer to the vault root
                   folders.push({
                     absPath: plugin.settings.outputVault,
                     relPath: path.basename(plugin.settings.outputVault)
                   })
+                  //add an option to create a new folder
                   folders.push({
                     absPath:"",
                     relPath:"Create new folder"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,6 @@
-import { Editor, MarkdownView } from 'obsidian';
+import { Editor, MarkdownView, TFile, TFolder } from 'obsidian';
 import VaultTransferPlugin from 'main';
-import { insertLinkToOtherVault, transferNote } from 'transfer';
+import { insertLinkToOtherVault, transferFolder, transferNote } from 'transfer';
 
 export function addCommands(plugin: VaultTransferPlugin) {
     /**
@@ -11,7 +11,7 @@ export function addCommands(plugin: VaultTransferPlugin) {
         id: 'transfer-note-to-vault',
         name: 'Transfer current note to other vault',
         editorCallback: (editor: Editor, view: MarkdownView) => {
-            transferNote(editor, view, plugin.app, plugin.settings);
+            transferNote(editor, view.file, plugin.app, plugin.settings);
         }
     });
 
@@ -25,4 +25,23 @@ export function addCommands(plugin: VaultTransferPlugin) {
             insertLinkToOtherVault(editor, view, plugin.settings);
         }
     });
+}
+
+export function addMenuCommands(plugin: VaultTransferPlugin) {
+    plugin.registerEvent(
+      plugin.app.workspace.on("file-menu", (menu, file) => {
+        menu.addItem((item) => {
+          item
+            .setTitle("Transfer to other vault")
+            .setIcon("arrow-right-circle")
+            .onClick(async () => {
+              if (file instanceof TFolder) {
+                transferFolder(file, plugin.app, plugin.settings)
+              } else if (file instanceof TFile) {
+                transferNote(null, file as TFile, plugin.app, plugin.settings);
+              }
+            });
+        });
+      })
+    );
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { addCommands } from 'commands';
+import { addCommands, addMenuCommands } from 'commands';
 import { Plugin } from 'obsidian';
 import { DEFAULT_SETTINGS, SettingTab, VaultTransferSettings } from 'settings';
 
@@ -6,9 +6,11 @@ export default class VaultTransferPlugin extends Plugin {
 	settings: VaultTransferSettings;
 
 	async onload() {
+		console.log('loading obsidian-vault-transfer plugin');
 		await this.loadSettings();
 
 		addCommands(this);
+		addMenuCommands(this);
 
 		this.addSettingTab(new SettingTab(this.app, this));
 	}
@@ -19,5 +21,9 @@ export default class VaultTransferPlugin extends Plugin {
 
 	async saveSettings() {
 		await this.saveData(this.settings);
+	}
+
+	onunload(): void {
+		console.log('unloading obsidian-vault-transfer plugin');
 	}
 }

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -1,0 +1,94 @@
+import { App, FuzzySuggestModal, Modal, Setting, TAbstractFile, TFile, TFolder, normalizePath } from 'obsidian';
+import VaultTransferPlugin from 'main';
+import { VaultTransferSettings } from 'settings';
+import { Folder } from 'commands';
+import { transferFolder, transferNote } from 'transfer';
+import * as fs from 'fs';
+
+/** Fuzzy modal where you can search a specific folder with the Path */
+
+
+export class FolderSuggestModal extends FuzzySuggestModal<Folder> {
+    plugin: VaultTransferPlugin;
+    settings: VaultTransferSettings;
+    app: App;
+    toTransfer: TAbstractFile; 
+    foldersList: Folder[]
+
+    constructor(plugin: VaultTransferPlugin, app: App, settings: VaultTransferSettings, folder: Folder[], toTransfer: TAbstractFile) {
+        super(plugin.app);
+        this.plugin = plugin;
+        this.settings = settings;
+        this.foldersList = folder;
+        this.app = app;
+        this.toTransfer = toTransfer;
+    }
+
+    getItems(): Folder[] {
+        return this.foldersList;
+    }
+
+    getItemText(item: Folder): string {
+        return item.relPath;
+    }
+
+    onChooseItem(item: Folder, evt: MouseEvent | KeyboardEvent): void {
+        if (item.absPath.length == 0) {
+            new CreateFolder(this.app, this.plugin, this.settings, item, this.toTransfer).open();
+        } else {
+            if (this.toTransfer instanceof TFolder) {
+                transferFolder(this.toTransfer, this.app, this.settings, item.absPath)
+            } else if (this.toTransfer instanceof TFile) {
+                transferNote(null, this.toTransfer as TFile, this.app, this.settings, undefined, item.absPath);
+            }
+        }
+    }
+}
+
+class CreateFolder extends Modal {
+    app: App;
+    plugin: VaultTransferPlugin;
+    settings: VaultTransferSettings;
+    folder: Folder;
+    toTransfer: TAbstractFile;
+
+    constructor(app: App, plugin: VaultTransferPlugin, settings: VaultTransferSettings, folder: Folder, toTransfer: TAbstractFile) {
+        super(app);
+        this.app = app;
+        this.plugin = plugin;
+        this.settings = settings;
+        this.folder = folder;
+        this.toTransfer = toTransfer;
+    }
+
+    onOpen() {
+        const { contentEl } = this;
+        contentEl.createEl('h2', { text: 'Create new folder' });
+        contentEl.createEl('p', { text: 'Please enter the name of the folder you want to create' });
+        new Setting(contentEl)
+            .setName('Folder name')
+            .setDesc("The folder will use the output vault as root")
+            .addText(text => text
+                .setPlaceholder('Folder name')
+                .setValue('')
+                .onChange(async (value) => {
+                    this.folder.relPath = value;
+                    this.folder.absPath = this.settings.outputVault + "/" + value;
+                }
+            ))
+        .addButton((button) => {
+            button
+                .setButtonText("Create folder")
+                .onClick(async () => {
+                    fs.mkdirSync(normalizePath(this.folder.absPath), { recursive: true });
+                    if (this.toTransfer instanceof TFolder) {
+                        transferFolder(this.toTransfer, this.app, this.settings, this.folder.absPath)
+                    } else if (this.toTransfer instanceof TFile) {
+                        transferNote(null, this.toTransfer as TFile, this.app, this.settings, undefined, this.folder.absPath);
+                    }
+                    this.close();
+                }
+            )
+        })
+    }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,6 +8,7 @@ export interface VaultTransferSettings {
     deleteOriginal: boolean; //only relevant if createLink is false
     moveToSystemTrash: boolean; //only relevant if deleteOriginal is true
     overwrite: boolean; //if set to false => skip file if it already exists
+    recreateTree: boolean; //if set to true => recreate the folder structure in the new vault
 }
 
 export const DEFAULT_SETTINGS: VaultTransferSettings = {
@@ -16,7 +17,8 @@ export const DEFAULT_SETTINGS: VaultTransferSettings = {
     createLink: true,
     deleteOriginal: false,
     moveToSystemTrash: false,
-    overwrite: false
+    overwrite: false,
+    recreateTree: false
 }
 
 export class SettingTab extends PluginSettingTab {
@@ -56,6 +58,16 @@ export class SettingTab extends PluginSettingTab {
                     this.plugin.settings.outputFolder = normalizePath(value);
                     await this.plugin.saveSettings();
                 }));
+        new Setting(containerEl)
+            .setName('Recreate Folder Structure')
+            .setDesc('If set to true, the folder structure of the original file will be recreated in the new vault.')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.recreateTree)
+                .onChange(async (value) => {
+                    this.plugin.settings.recreateTree = value;
+                    await this.plugin.saveSettings();
+                }
+            ));
         
         new Setting(containerEl)
             .setName('Create Link')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,14 +1,22 @@
 import VaultTransferPlugin from 'main';
-import { App, PluginSettingTab, Setting } from 'obsidian';
+import { App, PluginSettingTab, Setting, normalizePath } from 'obsidian';
 
 export interface VaultTransferSettings {
     outputVault: string;
     outputFolder: string;
+    createLink: boolean; 
+    deleteOriginal: boolean; //only relevant if createLink is false
+    moveToSystemTrash: boolean; //only relevant if deleteOriginal is true
+    overwrite: boolean; //if set to false => skip file if it already exists
 }
 
 export const DEFAULT_SETTINGS: VaultTransferSettings = {
     outputVault: '',
     outputFolder: '',
+    createLink: true,
+    deleteOriginal: false,
+    moveToSystemTrash: false,
+    overwrite: false
 }
 
 export class SettingTab extends PluginSettingTab {
@@ -25,6 +33,7 @@ export class SettingTab extends PluginSettingTab {
         containerEl.empty();
 
         containerEl.createEl('h2', { text: 'Settings' });
+        containerEl.createEl('h3', { text: 'Path settings' });
 
         new Setting(containerEl)
             .setName('Output Vault')
@@ -33,7 +42,7 @@ export class SettingTab extends PluginSettingTab {
                 .setPlaceholder('C:/MyVault')
                 .setValue(this.plugin.settings.outputVault)
                 .onChange(async (value) => {
-                    this.plugin.settings.outputVault = value;
+                    this.plugin.settings.outputVault = normalizePath(value);
                     await this.plugin.saveSettings();
                 }));
 
@@ -44,8 +53,58 @@ export class SettingTab extends PluginSettingTab {
                 .setPlaceholder('Unsorted/Transfer')
                 .setValue(this.plugin.settings.outputFolder)
                 .onChange(async (value) => {
-                    this.plugin.settings.outputFolder = value;
+                    this.plugin.settings.outputFolder = normalizePath(value);
                     await this.plugin.saveSettings();
                 }));
+        
+        new Setting(containerEl)
+            .setName('Create Link')
+            .setDesc('Add a link to the new file in the new vault to the current note. If set to false, the file will be left unchanged, but you can choose to delete the original with the setting below.')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.createLink)
+                .onChange(async (value) => {
+                    this.plugin.settings.createLink = value;
+                    await this.plugin.saveSettings();
+                    this.display();
+                }
+            ));
+        if (!this.plugin.settings.createLink) {
+            containerEl.createEl('h3', { text: 'Deleting the original file settings' });
+            new Setting(containerEl)
+                .setName('Delete Original')
+                .setDesc('If set to true, the original file will be deleted')
+                .addToggle(toggle => toggle
+                    .setValue(this.plugin.settings.deleteOriginal)
+                    .onChange(async (value) => {
+                        this.plugin.settings.deleteOriginal = value;
+                        await this.plugin.saveSettings();
+                        this.display();
+                    }
+                ));
+            if (this.plugin.settings.deleteOriginal) {
+                new Setting(containerEl)
+                    .setName('Move to System Trash')
+                    .setDesc('If set to true, the original file will be moved to the system trash. Otherwise, it will be moved to the vault trash.')
+                    .addToggle(toggle => toggle
+                        .setValue(this.plugin.settings.moveToSystemTrash)
+                        .onChange(async (value) => {
+                            this.plugin.settings.moveToSystemTrash = value;
+                            await this.plugin.saveSettings();
+                        }
+                    ));
+                }
+        }
+
+        containerEl.createEl('h3', { text: 'Other Settings' });
+        new Setting(containerEl)
+            .setName('Overwrite')
+            .setDesc('If set to false, the file will be skipped if it already exists in the other vault.')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.overwrite)
+                .onChange(async (value) => {
+                    this.plugin.settings.overwrite = value;
+                    await this.plugin.saveSettings();
+                }
+            ));
     }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -34,8 +34,7 @@ export class SettingTab extends PluginSettingTab {
 
         containerEl.empty();
 
-        containerEl.createEl('h2', { text: 'Settings' });
-        containerEl.createEl('h3', { text: 'Path settings' });
+        containerEl.createEl('h2', { text: 'Path settings' });
 
         new Setting(containerEl)
             .setName('Output Vault')

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -167,23 +167,6 @@ function showErrorIfSettingsInvalid(settings: VaultTransferSettings): boolean {
 }
 
 /**
- * @deprecated The obsidian function "normalizePath" is now available, which does the same thing, in a more robust way.
- * Improves consistency of slashes in a path.
- *
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function cleanPath(path: string): string {
-    //normalize path
-    return path.trim()
-        // Replace '\' with '/'
-        .replaceAll("\\", "/")
-        // Remove beginning '/'
-        .replace(/^\//, "")
-        // Remove end '/'
-        .replace(/\/$/, "");
-}
-
-/**
  * Copy all attachments of a file to a new vault -- Respecting the folder structure of the attachments
  * @param file {TFile} The file to copy the attachments from
  * @param app {App} Obsidian app

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -32,11 +32,14 @@ export function transferNote(editor: Editor, view: MarkdownView, app: App, setti
             return;
         }
 
-        // Check if file exists, so we don't overwrite anything
-        const fileExists = fs.existsSync(outputPath);
-        if (fileExists) {
+        if (fs.existsSync(outputPath)) {
+            if (settings.overwrite) {
+                fs.unlinkSync(outputPath);
+            }
+            else {
             showNotice("Error: File already exists");
             return;
+        }
         }
 
         //get list of all attachments
@@ -44,9 +47,14 @@ export function transferNote(editor: Editor, view: MarkdownView, app: App, setti
         // Copy to new file in other vault
         fs.copyFileSync(`${thisVaultPath}/${view.file.path}`, outputPath);
 
+        if (settings.createLink) {
         // Replace original file with link
         const link = createVaultFileLink(fileDisplayName, outputVault);
         editor.setValue(link);
+        } else if (settings.deleteOriginal) {
+            // Delete original file
+            app.vault.trash(view.file, settings.moveToSystemTrash);
+        }
     }
     catch (e) {
         showNotice(`Error copying file: ${e}`);

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -27,7 +27,7 @@ export async function transferNote(editor: Editor | null, file: TFile, app: App,
         if (settings.recreateTree) {
             outputPath = normalizePath(`${outputFolderPath}/${file.path}`);
         }
-        showNotice(`Copying ${file.path} to ${outputPath}`);
+        if (!recursive) showNotice(`Copying ${file.path} to ${outputPath}`);
 
         // Check if directory exists to avoid error when copying
         const folderExists = fs.existsSync(outputFolderPath);
@@ -93,6 +93,7 @@ export function transferFolder(folder: TFolder, app: App, settings: VaultTransfe
         if (settings.deleteOriginal && !settings.createLink) {
             app.vault.trash(folder, settings.moveToSystemTrash);
         }
+        showNotice(`Finished copying ${file.path}`);
     }
 }
 

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { App, Editor, FileSystemAdapter, MarkdownView } from 'obsidian';
+import { App, Editor, FileSystemAdapter, MarkdownView, TFile, normalizePath } from 'obsidian';
 import { VaultTransferSettings } from 'settings';
 import { showNotice } from 'utils';
 
@@ -14,8 +14,8 @@ export function transferNote(editor: Editor, view: MarkdownView, app: App, setti
             return;
         }
 
-        const outputVault = cleanPath(settings.outputVault);
-        const outputFolder = cleanPath(settings.outputFolder);
+        const outputVault = normalizePath(settings.outputVault);
+        const outputFolder = normalizePath(settings.outputFolder);
 
         // Get paths
         const fileSystemAdapter = app.vault.adapter as FileSystemAdapter;
@@ -77,7 +77,7 @@ export function insertLinkToOtherVault(editor: Editor, view: MarkdownView, setti
  */
 function createVaultFileLink(fileDisplayName: string, outputVault: string): string {
     // Get content for link
-    const vaultPathArray = cleanPath(outputVault).split("/");
+    const vaultPathArray = normalizePath(outputVault).split("/");
     const vaultName = vaultPathArray[vaultPathArray.length - 1];
     const urlOtherVault = encodeURI(vaultName);
     const urlFile = encodeURI(fileDisplayName);
@@ -107,9 +107,13 @@ function showErrorIfSettingsInvalid(settings: VaultTransferSettings): boolean {
 }
 
 /**
+ * @deprecated The obsidian function "normalizePath" is now available, which does the same thing, in a more robust way.
  * Improves consistency of slashes in a path.
+ *
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function cleanPath(path: string): string {
+    //normalize path
     return path.trim()
         // Replace '\' with '/'
         .replaceAll("\\", "/")

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -37,9 +37,9 @@ export function transferNote(editor: Editor, view: MarkdownView, app: App, setti
                 fs.unlinkSync(outputPath);
             }
             else {
-            showNotice("Error: File already exists");
-            return;
-        }
+                showNotice("Error: File already exists");
+                return;
+            }
         }
 
         //get list of all attachments
@@ -49,15 +49,15 @@ export function transferNote(editor: Editor, view: MarkdownView, app: App, setti
 
         if (settings.createLink) {
         // Replace original file with link
-        const link = createVaultFileLink(fileDisplayName, outputVault);
-        editor.setValue(link);
+            const link = createVaultFileLink(fileDisplayName, outputVault);
+            editor.setValue(link);
         } else if (settings.deleteOriginal) {
             // Delete original file
             app.vault.trash(view.file, settings.moveToSystemTrash);
         }
     }
     catch (e) {
-        showNotice(`Error copying file: ${e}`);
+        showNotice(`Error copying file`, e);
     }
 }
 

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -92,7 +92,7 @@ function createVaultFileLink(fileDisplayName: string, outputVault: string): stri
  * @returns True if an error was shown, otherwise false.
  */
 function showErrorIfSettingsInvalid(settings: VaultTransferSettings): boolean {
-    var message: string | null = null;
+    let message: string | null = null;
 
     // Check settings
     if (settings.outputVault.trim().length == 0) {

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -70,6 +70,11 @@ export async function transferNote(editor: Editor | null, file: TFile, app: App,
     }
 }
 
+/**
+ * Generate a list of all files in a folder (including subfolders)
+ * @param file {TFolder} The folder to get files from
+ * @returns {TFile[]} A list of all TFiles files in the folder
+ */
 function listToTransfer(file: TFolder) {
     const files = file.children;
     const filesToTransfer:TFile[] = [];
@@ -84,7 +89,12 @@ function listToTransfer(file: TFolder) {
     return filesToTransfer;
 }
 
-
+/**
+ * Transfer a folder and all its contents to another vault
+ * @param folder {TFolder} The folder to transfer
+ * @param app {App} Obsidian app
+ * @param settings {VaultTransferSettings} Plugin settings
+ */
 export function transferFolder(folder: TFolder, app: App, settings: VaultTransferSettings) {
     const files = listToTransfer(folder);
     for (const file of files) {
@@ -169,6 +179,13 @@ function cleanPath(path: string): string {
         .replace(/\/$/, "");
 }
 
+/**
+ * Copy all attachments of a file to a new vault -- Respecting the folder structure of the attachments
+ * @param file {TFile} The file to copy the attachments from
+ * @param app {App} Obsidian app
+ * @param newVault {string} The path of the new vault, where the attachments should be copied to. 
+ * @param thisVaultPath {string} The path of the current vault, where the attachments are located.
+ */
 function copyAllAttachments(file: TFile, app: App, newVault: string, thisVaultPath: string) {
     //Get all attachments of the file, aka embedded things (pdf, image...)
     const attachments = app.metadataCache.getFileCache(file)?.embeds ?? [];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { Notice } from "obsidian";
 
-export function showNotice(message: string) {
-    new Notice(message);
+export function showNotice(...message: unknown[]) {
+    new Notice(message.join(" "));
+    console.log(message);
 }


### PR DESCRIPTION
First, close #5 

## Miscellaneous

- Improved the functionality of `normalizePath` using ObsidianAPI.
- Added an option to delete the file after transfer.
- Included an option to disable link generation (disabling link generation is necessary to enable file deletion).
- Added an option to maintain the folder structure.
- Implemented `onload` and `onunload` message functionality.

## Commands in the File Menu
The File Menu now includes the following options for file and folder transfer. Please note that the new submenu is not yet described in the ObsidianAPI. There are two commands available:

- Transfer to Another Vault (follows specified settings).
- Transfer to Another Vault by selecting a folder or creating a new folder.

> **Note**  
> - Since the editor does not use the file menu, I have employed an alternative method to add the new vault link.
> - Additionally, the folder hierarchy will be preserved during the transfer process.