### PR TITLE
feat(path): allow to remove subpath if recreateTree used

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -75,7 +75,7 @@ export class SettingTab extends PluginSettingTab {
             new Setting(containerEl)
                 .setName('Remove Path')
                 .setDesc('Remove parts of the path, separate in the settings by comma or new line.')
-                .addText(text => 
+                .addTextArea(text => 
                     text
                         .setPlaceholder('00. ARCHIVES')
                         .setValue(this.plugin.settings.removePath.join(' ,'))

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,6 +9,7 @@ export interface VaultTransferSettings {
     moveToSystemTrash: boolean; //only relevant if deleteOriginal is true
     overwrite: boolean; //if set to false => skip file if it already exists
     recreateTree: boolean; //if set to true => recreate the folder structure in the new vault
+    removePath: string[]; //allow to remove parts of the path, separate in the settings by space/comma
 }
 
 export const DEFAULT_SETTINGS: VaultTransferSettings = {
@@ -18,7 +19,8 @@ export const DEFAULT_SETTINGS: VaultTransferSettings = {
     deleteOriginal: false,
     moveToSystemTrash: false,
     overwrite: false,
-    recreateTree: false
+    recreateTree: false,
+    removePath: []
 }
 
 export class SettingTab extends PluginSettingTab {
@@ -64,9 +66,25 @@ export class SettingTab extends PluginSettingTab {
                 .setValue(this.plugin.settings.recreateTree)
                 .onChange(async (value) => {
                     this.plugin.settings.recreateTree = value;
+                    this.display();
                     await this.plugin.saveSettings();
                 }
             ));
+        
+        if (this.plugin.settings.recreateTree) {
+            new Setting(containerEl)
+                .setName('Remove Path')
+                .setDesc('Remove parts of the path, separate in the settings by comma or new line.')
+                .addText(text => 
+                    text
+                        .setPlaceholder('00. ARCHIVES')
+                        .setValue(this.plugin.settings.removePath.join(' ,'))
+                        .onChange(async (value) => {
+                            this.plugin.settings.removePath = value.split(/[,\n]\W*/);
+                            await this.plugin.saveSettings();
+                        })
+                );
+        }
         
         new Setting(containerEl)
             .setName('Create Link')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -77,8 +77,8 @@ export class SettingTab extends PluginSettingTab {
                 .setDesc('Removes the specified folders from the output path, if present. Separate folders by using a comma or a new line. Names are case insensitive.')
                 .addTextArea(text => 
                     text
-                        .setPlaceholder('00. ARCHIVES')
-                        .setValue(this.plugin.settings.removePath.join(' ,'))
+                        .setPlaceholder('RemoveThisFolder, AndThis')
+                        .setValue(this.plugin.settings.removePath.join(', '))
                         .onChange(async (value) => {
                             const rawPaths = value.split(/[,\n]/);
                             const cleanPaths: string[] = [];

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -80,9 +80,8 @@ export class SettingTab extends PluginSettingTab {
                         .setPlaceholder('00. ARCHIVES')
                         .setValue(this.plugin.settings.removePath.join(' ,'))
                         .onChange(async (value) => {
-                            var rawPaths = value.split(/[,\n]/);
-
-                            var cleanPaths: string[] = [];
+                            const rawPaths = value.split(/[,\n]/);
+                            const cleanPaths: string[] = [];
                             // Remove empty strings, and clean up paths
                             for (const path of rawPaths) {
                                 const trimmedPath = path.trim();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -73,8 +73,8 @@ export class SettingTab extends PluginSettingTab {
         
         if (this.plugin.settings.recreateTree) {
             new Setting(containerEl)
-                .setName('Remove Path')
-                .setDesc('Remove parts of the path, separate in the settings by comma or new line.')
+                .setName('Remove Folders From Path')
+                .setDesc('Removes the specified folders from the output path, if present. Separate folders by using a comma or a new line. Names are case insensitive.')
                 .addTextArea(text => 
                     text
                         .setPlaceholder('00. ARCHIVES')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -80,7 +80,19 @@ export class SettingTab extends PluginSettingTab {
                         .setPlaceholder('00. ARCHIVES')
                         .setValue(this.plugin.settings.removePath.join(' ,'))
                         .onChange(async (value) => {
-                            this.plugin.settings.removePath = value.split(/[,\n]\W*/);
+                            var rawPaths = value.split(/[,\n]/);
+
+                            var cleanPaths: string[] = [];
+                            // Remove empty strings, and clean up paths
+                            for (const path of rawPaths) {
+                                const trimmedPath = path.trim();
+                                if (trimmedPath == "") {
+                                    continue;
+                                }
+                                cleanPaths.push(normalizePath(trimmedPath));
+                            }
+
+                            this.plugin.settings.removePath = cleanPaths;
                             await this.plugin.saveSettings();
                         })
                 );

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -11,7 +11,7 @@ import { showNotice } from 'utils';
  */
 function removePartOfPath(settings: VaultTransferSettings, path: string):string {
     for (const part of settings.removePath) {
-        path = path.replace(part, "");
+        path = path.replace(RegExp(part, "gi"), "");
     }
     return normalizePath(path);
 }

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -3,7 +3,13 @@ import { App, Editor, FileSystemAdapter, MarkdownView, TFile, TFolder, normalize
 import { VaultTransferSettings } from 'settings';
 import { showNotice } from 'utils';
 
-function removePartOfPath(settings: VaultTransferSettings, path: string) {
+/**
+ * Simple function that remove a part of a path using the settings "removePath"
+ * @param settings {VaultTransferSettings} 
+ * @param path {string}
+ * @returns {string} The path without the parts to remove or the original path, depending on the settings
+ */
+function removePartOfPath(settings: VaultTransferSettings, path: string):string {
     for (const part of settings.removePath) {
         path = path.replace(part, "");
     }

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -2,6 +2,14 @@ import * as fs from 'fs';
 import { App, Editor, FileSystemAdapter, MarkdownView, TFile, TFolder, normalizePath } from 'obsidian';
 import { VaultTransferSettings } from 'settings';
 import { showNotice } from 'utils';
+
+function removePartOfPath(settings: VaultTransferSettings, path: string) {
+    for (const part of settings.removePath) {
+        path = path.replace(part, "");
+    }
+    return normalizePath(path);
+}
+
 /**
  * Copies the content of the current note to another vault, then replaces existing note contents with a link to the new file.
  */
@@ -27,6 +35,7 @@ export async function transferNote(editor: Editor | null, file: TFile, app: App,
             outputPath = normalizePath(`${outputFolderPath}/${fileName}`);
             if (settings.recreateTree) {
                 outputPath = normalizePath(`${outputFolderPath}/${file.path}`);
+                outputPath = removePartOfPath(settings, outputPath);
             }
         } else {
             outputFolderPath = normalizePath(outputPath);


### PR DESCRIPTION
Hello!
Using the plugin, I needed to remove some part of the path. So, I added a new setting, as a `string[]`, that allow to remove a part. The final path is normalized, as always, using the Obsidian API.
This function is only used if the `recreateTree` is `true`. 