### PR TITLE
Added setting 'Tag to Assign'

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,6 +17,7 @@ export const DEFAULT_SETTINGS: VaultTransferSettings = {
     outputFolder: '',
     createLink: true,
     deleteOriginal: false,
+  	tagtoAssign:"",
     moveToSystemTrash: false,
     overwrite: false,
     recreateTree: false,
@@ -140,6 +141,18 @@ export class SettingTab extends PluginSettingTab {
                 );
         }
 
+		// Tag to assign to transferred note
+	    if (!this.plugin.settings.deleteOriginal) {
+	      new import_obsidian5.Setting(containerEl).setName("Tag to Assign").setDesc(
+	        "Add a tag to be assigned automatically in FrontMatter after transferring a note (without `#`)"
+	      ).addText(
+	        (tag) => tag.setPlaceholder("Transferred").setValue(this.plugin.settings.tagtoAssign).onChange(async (value) => {
+	          this.plugin.settings.tagtoAssign = value.replace(/ /g, ""); // Keep tag name without spaces at the end
+	          await this.plugin.saveSettings();
+	        })
+	      );
+	    }
+		
         new Setting(containerEl).setName('Other').setHeading();
 
         new Setting(containerEl)

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -79,6 +79,18 @@ export async function transferNote(editor: Editor | null, file: TFile, app: App,
         // Copy to new file in other vault
         fs.copyFileSync(normalizePath(`${thisVaultPath}/${file.path}`), outputPath);
 
+	    // If a tag to assign was specified in settings, assign it to current note
+	    if (!settings.deleteOriginal && settings.tagtoAssign != "") {
+	      const tagtoAssign = settings.tagtoAssign;
+	      app.fileManager.processFrontMatter(file, (fm: any) => {
+		      if (!fm.tags) {
+		        fm.tags = new Set(tagtoAssign);
+		      } else {
+		        let curTags = [...fm.tags];
+				fm.tags = new Set([...curTags, tagtoAssign]);
+		      }
+	      })
+	    };
         if (settings.createLink) {
             // Replace original file with link
             const link = createVaultFileLink(fileDisplayName, outputVault);


### PR DESCRIPTION
Added a setting 'Tag to Assign' to allow assigning a tag which will be assigned in the source vault, only in case the source note is not deleted.

Please bare with me, as this was my first attempt at it, but seems to be working properly.

Fixes #17 